### PR TITLE
Topic-based Guidelines: Wiki Content Change Notices

### DIFF
--- a/content/developer/packaging/_index.md
+++ b/content/developer/packaging/_index.md
@@ -7,7 +7,8 @@ Welcome! If you are reading this, you are probably interested in contributing to
 If you are new to packaging for AOSC OS, please first take a look at the [Intro to Package Maintenance: Basics](@/developer/packaging/basics.md). After that, read [Intro to Package Maintenance: Advanced Techniques](@/developer/packaging/advanced-techniques.md) for some very common techniques used in day-to-day packaging.
 
 In order to ensure the quality of our packages (and reduce wtf moments for other developers), please follow these guidelines.
-- [AOSC OS Maintenance Guidelines](@/developer/packaging/maintenance-guidelines.md)
+
+- [AOSC OS Topic-Based Maintenance Guidelines](@/developer/packaging/topic-based-maintenance-guideline.md)
 - [AOSC OS Package Styling Manual](@/developer/packaging/package-styling-manual.md)
 
 Also, you may want to read these documentations about the tools we use.

--- a/content/developer/packaging/_index.zh.md
+++ b/content/developer/packaging/_index.zh.md
@@ -8,7 +8,7 @@ title = "打包"
 
 为了确保构建好的软件包的质量，请遵循下面的这些指南：
 
-- [AOSC OS 维护指南](@/developer/packaging/maintenance-guidelines.zh.md)
+- [AOSC OS 主题制维护指南 (English)](@/developer/packaging/topic-based-maintenance-guideline.md)
 - [AOSC OS 软件包样式指南](@/developer/packaging/package-styling-manual.zh.md)
 
 想要进一步了解我们在打包中常用的一些应用程序，可以阅读下面的文档：

--- a/content/developer/packaging/advanced-techniques.md
+++ b/content/developer/packaging/advanced-techniques.md
@@ -3,6 +3,10 @@ title = "Intro to Package Maintenance: Advanced Techniques"
 description = "This article is sponsered by Commit-O-Matic™"
 +++
 
+> **Attention: The maintenance guideline that this introduction is describing has been deprecated from October 25, 2020.** We've switched to a newly-proposed [Topic-Based Maintenance Guidelines](@/developer/packaging/topic-based-maintenance-guideline.md). Before we update this document, you could refer to that document instead, or stay tuned.
+
+---
+
 > So you want to make a package, you've got the urge to make a package, you've got the nerve to make a package, so go ahead, so go ahead, so go ahead and make a package we can use\!
 
 After learning the [basics](@/developer/packaging/basics.md) about building packages, we can now start exploring some advanced techniques.
@@ -165,9 +169,9 @@ pushpkg LDAP_IDENTITY BRANCH
 Note that `LDAP_IDENTITY` and `BRANCH` are by definition users and repositories on our [Community Repository](https://repo.aosc.io/). Contributors are audited before an LDAP identities are granted by our Infrustructure Work Group - we will get in touch with you via your first PR to our ABBS tree.
 
 1.  A great name, I know…
-    
+
     In order to actually utilize these information, there is a tool called [findupd](https://github.com/AOSC-Dev/scriptlets/tree/master/findupd), which automatically downloads the infomation from `PISS` and change the corresponding version in package's `spec` file. Simply clone the repository, copy all executables and Python scripts into your `PATH`, and trigger:
-    
+
     ``` bash
     cd TREE/
     findupd-stable extra-gnome

--- a/content/developer/packaging/advanced-techniques.zh.md
+++ b/content/developer/packaging/advanced-techniques.zh.md
@@ -3,6 +3,8 @@ title = "软件包维护入门：进阶"
 description = "本文由 Commit-O-Matic™ 赞助"
 +++
 
+> **注意：本入门所描述的维护指南自 2020 年 10 月 25 日起已被弃用。**我们已经开始实践新提出的[话题制维护指南 (English)](@/developer/packaging/topic-based-maintenance-guideline.md)。在我们更新这篇文档之前，您可以左转阅读那份指南，或者坐等更新。
+
 在学习了软件包构建的 [基本技能](@/developer/packaging/basics.zh.md) 之后，让我们来进一步了解打包过程中经常用到的一些进阶技术吧！
 
 请注意，您并不需要逐字阅读这篇文档，只需快速浏览一下，记住其中关键的概念，在实际开发过程中遇到问题时再回来参考这篇文档。
@@ -43,7 +45,7 @@ description = "本文由 Commit-O-Matic™ 赞助"
 
 构建脚本应该放置于 `autobuild/build`。一旦这样做，则构建脚本类型将被自动指定为 `self`（除非您手动声明了 `ABTYPE=`），这意味着 `Autobuild3` 会直接执行此脚本而不再做其它尝试。
 
-构建脚本本身看起来应该和您手动编译程序时使用到的一些脚本非常相似。但是一个关键的区别是编译好的程序不应被安装到系统根目录下。相反，它应该安装在 `$PKGDIR` 中，这样子 `Autobuild3` 才可以基于该目录中的文件生成正确的 DEB 包。例如，如果您有一个名为 `hugo` 的二进制文件，则应通过下面的方式将其安装到目标路径的 `bin` 目录中： 
+构建脚本本身看起来应该和您手动编译程序时使用到的一些脚本非常相似。但是一个关键的区别是编译好的程序不应被安装到系统根目录下。相反，它应该安装在 `$PKGDIR` 中，这样子 `Autobuild3` 才可以基于该目录中的文件生成正确的 DEB 包。例如，如果您有一个名为 `hugo` 的二进制文件，则应通过下面的方式将其安装到目标路径的 `bin` 目录中：
 
 ``` bash
 abinfo "Installing Hugo binary..."
@@ -101,7 +103,7 @@ autobuild/overrides/usr/share/applications/foo.desktop
 
 接下来让我们看看 `git diff`，您应该能够看到 `VER` 和 `REL` 行上的一系列更改。
 
-要注意的是，如果您希望为软件进行跨版本更新，请使用 `findupd` 而不是 `findupd-stable`。 
+要注意的是，如果您希望为软件进行跨版本更新，请使用 `findupd` 而不是 `findupd-stable`。
 
 ## 批量更新校验和
 
@@ -163,8 +165,8 @@ pushpkg LDAP_IDENTITY BRANCH
 
 1.  PISS 这个名字起得不错吧（笑）。
 
-    为了真正利用上游的版本信息，我们开发了一个叫做 [findupd](https://github.com/AOSC-Dev/scriptlets/tree/master/findupd) 的工具，它会自动从 `PISS` 获取信息并更改每个软件包 `spec` 文件中的版本信息。您需要做的就是克隆 `findupd` 的仓库，将所有可执行文件和 Python 脚本复制到 `PATH` 中，然后执行： 
-    
+    为了真正利用上游的版本信息，我们开发了一个叫做 [findupd](https://github.com/AOSC-Dev/scriptlets/tree/master/findupd) 的工具，它会自动从 `PISS` 获取信息并更改每个软件包 `spec` 文件中的版本信息。您需要做的就是克隆 `findupd` 的仓库，将所有可执行文件和 Python 脚本复制到 `PATH` 中，然后执行：
+
     ``` bash
     cd TREE/
     findupd-stable extra-gnome

--- a/content/developer/packaging/basics.md
+++ b/content/developer/packaging/basics.md
@@ -4,9 +4,11 @@ description = "Introductory Guide to AOSC OS Packaging"
 date = 2020-08-03T12:01:46.691Z
 +++
 
+> **Attention: The maintenance guideline that this introduction is describing has been deprecated from October 25, 2020.** We've switched to a newly-proposed [Topic-Based Maintenance Guidelines](@/developer/packaging/topic-based-maintenance-guideline.md). Before we update this document, you could refer to that document instead, or stay tuned.
+
 **NOTICE**: This guide assumes you have moderate knowledge about Linux and its CLI (command line interface). Also, you need to have access to a Linux computer with `root` access.
 
-# Meet the tools 
+# Meet the tools
 
 We will need these tools in order to build packages. Don't worry about them for now, we will investigate them later.
 
@@ -265,7 +267,7 @@ If you are updating the version of an exisiting package, it should be like this:
 And please mention all the specific changes made to the package (i.e., dependency changes, feature enablement, etc.) in the long log, for instance:
 
     bash: update to 5.2
-    
+
     - Make a symbolic link from /bin/bash to /bin/sh for program compatibility.
     - Install HTML documentations.
     - Build with -O3 optimisation.

--- a/content/developer/packaging/basics.zh.md
+++ b/content/developer/packaging/basics.zh.md
@@ -4,6 +4,8 @@ description = "了解 AOSC OS 打包流程"
 date = 2020-08-04T02:13:57.919Z
 +++
 
+> **注意：本入门所描述的维护指南自 2020 年 10 月 25 日起已被弃用。**我们已经开始实践新提出的[话题制维护指南 (English)](@/developer/packaging/topic-based-maintenance-guideline.md)。在我们更新这篇文档之前，您可以左转阅读那份指南，或者坐等更新。
+
 **注意**：这篇指南假定您对 Linux 和它的命令行界面有一定的认识。此外，您还需要有一台您本人拥有 `root` 访问权限的装有 Linux 的电脑。
 
 # 需要用到的工具
@@ -18,17 +20,17 @@ date = 2020-08-04T02:13:57.919Z
   - [Autobuild3](https://github.com/AOSC-Dev/autobuild3/)
       - 用于运行构建脚本。
   - [pushpkg](https://github.com/AOSC-Dev/scriptlets/tree/master/pushpkg)
-      - 将构建好的软件包推送到官方软件仓库。 
+      - 将构建好的软件包推送到官方软件仓库。
 
 # 发行周期
 
-AOSC OS 采用的是半滚动更新模型，通常每个发布周期都为时三个月。这意味着 AOSC OS 和 Arch Linux 等滚动发行版一样是没有版本号的。但是，在 [aosc-os-abbs](https://github.com/AOSC-Dev/aosc-os-abbs) 树中，[AOSC OS Core](https://github.com/AOSC-Dev/AOSC-os-abbs/blob/testing-proposed/README.CORE.md) 是由一组软件包构建而成的，这组软件包由运行时库（例如 GNU C Library）和工具链（例如 GCC）组成。这组包以版本化的方式更新（Core 7.0.1、7.0.2、7.1.1 等）。此外，AOSC OS 软件仓库中所有更新都需要在一个 `*-proposed` 软件仓库中作经过一段时间的测试。 
+AOSC OS 采用的是半滚动更新模型，通常每个发布周期都为时三个月。这意味着 AOSC OS 和 Arch Linux 等滚动发行版一样是没有版本号的。但是，在 [aosc-os-abbs](https://github.com/AOSC-Dev/aosc-os-abbs) 树中，[AOSC OS Core](https://github.com/AOSC-Dev/AOSC-os-abbs/blob/testing-proposed/README.CORE.md) 是由一组软件包构建而成的，这组软件包由运行时库（例如 GNU C Library）和工具链（例如 GCC）组成。这组包以版本化的方式更新（Core 7.0.1、7.0.2、7.1.1 等）。此外，AOSC OS 软件仓库中所有更新都需要在一个 `*-proposed` 软件仓库中作经过一段时间的测试。
 
 我们有两个主要分支，分别是 `stable` 和 `testing`，还有三个开发分支 `stable-proposed`、`testing-proposed` 和 `explosive`。
 
 `stable-proposed` 没有冻结期，但这个分支只接受小版本更新（也就是说版本号 `x.y.z` 中只有 `z` 变动了）、安全更新、漏洞修复，还有 [一些例外](@/developer/packaging/cycle-exceptions.md)，这个分支的更新每周都会被合并到 `stable` 分支。
 
-`testing-proposed` 是主要的工作分支。引入新软件包和已有软件包的大版本更新（例如 Firefox 78 -> 79）通常都在此分支进行。开发工作遵循三个月一周期的迭代计划（可以参考 [Winter 2020 的迭代计划](https://github.com/AOSC-Dev/AOSC-os-abbs/issues/2073))。在前两个月，开发人员会构建新软件包或主要版本更新，随后在 `testing-proposed` 进行测试。 
+`testing-proposed` 是主要的工作分支。引入新软件包和已有软件包的大版本更新（例如 Firefox 78 -> 79）通常都在此分支进行。开发工作遵循三个月一周期的迭代计划（可以参考 [Winter 2020 的迭代计划](https://github.com/AOSC-Dev/AOSC-os-abbs/issues/2073))。在前两个月，开发人员会构建新软件包或主要版本更新，随后在 `testing-proposed` 进行测试。
 
 在最后一个月的开头，`testing-proposed` 会被合并到 `testing`。在这个月，启用 `testing` 软件仓库的用户将收到更新，并帮助测试它们。如果一切顺利，到月底，`testing` 就会被合并到 `stable`，从而完成整个周期。在这段时间内，`testing-proposed` 分支则会被冻结，不再接受新更改。
 
@@ -46,7 +48,7 @@ cd ~/ciel
 ciel init
 ```
 
-接下来我们部署 `BuildKit`。`BuildKit` 是一个最小化的 AOSC OS 变体，专门用于打包或容器化开发。它包含了 ACBS 和 Autobuild3，因此我们不需要做额外的配置。 
+接下来我们部署 `BuildKit`。`BuildKit` 是一个最小化的 AOSC OS 变体，专门用于打包或容器化开发。它包含了 ACBS 和 Autobuild3，因此我们不需要做额外的配置。
 
 ``` bash
 ciel load-os
@@ -71,13 +73,13 @@ ciel load-tree # 默认情况下，ciel 会加载官方的树
 
 好了，现在我们已经把打包环境配置好，可以尝试构建一个已有的包了。让我们从一个相对简单的例子开始，`extra-multimedia/flac`。
 
-在此之前，我们需要创建一个 Ciel 实例。建议对不同的分支使用不同的实例： 
+在此之前，我们需要创建一个 Ciel 实例。建议对不同的分支使用不同的实例：
 
 ``` bash
 ciel add stable # 因为我们准备为 stable 分支构建这个包
 ```
 
-确保我们的树在 `stable` 分支上。 
+确保我们的树在 `stable` 分支上。
 
 ``` bash
 cd TREE
@@ -159,7 +161,7 @@ CHKSUM="sha256::1e8fe133a195c29a8e2aa3b1c56e5bc77e7f5534f2dd92e09faabe2ca2d85f45
 
 ## `autobuild/`
 
-这是所有 `Autobuild3` 脚本和声明文件所在的目录。`Autobuild3` 是一个复杂的构建系统，它可以自动规划构建的流程，比如使用哪个构建系统，使用哪个构建参数等等。 
+这是所有 `Autobuild3` 脚本和声明文件所在的目录。`Autobuild3` 是一个复杂的构建系统，它可以自动规划构建的流程，比如使用哪个构建系统，使用哪个构建参数等等。
 
 ## `autobuild/defines`
 
@@ -190,7 +192,7 @@ PKGDES="Improved tiling WM (window manager)"
 PKGCONFL="i3-gaps"
 ```
 
-实际上，您可以在 `defines` 中写 Bash 逻辑。这在为特定平台添加标志或依赖项时很有用，但我们**不建议**您这样做，将来也可能直接禁止这样做。要为特定平台添加信息，请使用 `$VAR__$ARCH`。 
+实际上，您可以在 `defines` 中写 Bash 逻辑。这在为特定平台添加标志或依赖项时很有用，但我们**不建议**您这样做，将来也可能直接禁止这样做。要为特定平台添加信息，请使用 `$VAR__$ARCH`。
 
 要查看完整的可用配置项，请查看 [Autobuild3 维基](https://github.com/AOSC-Dev/aosc-os-abbs/wiki/Autobuild3)。
 
@@ -208,7 +210,7 @@ PKGCONFL="i3-gaps"
 
 这个程序提供了一个简单的命令以控制笔记本电脑的背光。因为它只使用文件 API 与背光子系统交互，所以这个程序非常简单，不需要依赖除了 `glibc` 之外的其它东西。
 
-我们假定您已经配置好了 Ciel，让我们返回到 `TREE` 目录。首先，确保您位于正确的分支。如上所述，在每个周期的前两个月，您应该使用 `testing-proposed`，而最后一个月，您应该使用 `explosive`。 
+我们假定您已经配置好了 Ciel，让我们返回到 `TREE` 目录。首先，确保您位于正确的分支。如上所述，在每个周期的前两个月，您应该使用 `testing-proposed`，而最后一个月，您应该使用 `explosive`。
 
 由于这个软件很显然是一个实用工具，我们在 `TREE/extra-utils` 下创建目录 `light`。
 
@@ -263,14 +265,14 @@ AOSC OS 对提交记录有着非常严格的格式要求。这里我们会提及
 这里我们建议您额外提及您对软件包做了哪些修改（例如依赖项的修改、标志的选择等等），例如：
 
     bash: update to 5.2
-    
+
     - Make a symbolic link from /bin/bash to /bin/sh for program compatibility.
     - Install HTML documentations.
     - Build with -O3 optimisation.
 
 ## 将软件包推送到软件仓库
 
-在成功构建软件包之后，软件包维护者会将把本地 Git 更改推送到树中，并将相应的包推送到官方软件仓库。 
+在成功构建软件包之后，软件包维护者会将把本地 Git 更改推送到树中，并将相应的包推送到官方软件仓库。
 
 将软件包推送到官方软件仓库可以用 [pushpkg](https://github.com/AOSC-Dev/scriptlets/tree/master/pushpkg) 完成。操作起来也很简单，只需下载脚本，将脚本添加到 PATH 并确保它是可执行的（`0755`）。然后，在 `OUTPUT` 目录中调用 `pushpkg`。在这个过程中，您需要提供 LDAP 凭据，并指定目标软件仓库（`stable`、`testing` 等）。
 

--- a/content/developer/packaging/cycle-exceptions.md
+++ b/content/developer/packaging/cycle-exceptions.md
@@ -6,6 +6,8 @@ date = 2020-05-04T03:35:43.402Z
 tags = ["dev-sys"]
 +++
 
+> **Attention: This guideline has been deprecated from October 25, 2020.** We've switched to a newly-proposed [Topic-Based Maintenance Guidelines](@/developer/packaging/topic-based-maintenance-guideline.md); please refer to that document instead.
+
 # Rationale and Definition
 
 Since the monthly update cycle was introduced to AOSC OS in July of 2017 (and later, seasonal update cycles introduced since July 2018), packages which represents feature, and non-bugfix/security updates should first have their build configurations pushed to the [testing-proposed](https://github.com/AOSC-Dev/aosc-os-abbs/tree/testing-proposed) of the [ABBS Tree](https://github.com/AOSC-Dev/aosc-os-abbs), uploaded to the [testing-proposed](https://repo.aosc.io/debs/pool/testing-proposed/) repositories - and made available in the stable repository at the end of each seasonal cycle after testing.

--- a/content/developer/packaging/dotnet.md
+++ b/content/developer/packaging/dotnet.md
@@ -6,6 +6,8 @@ date = 2020-05-04T03:35:48.616Z
 tags = ["dev-sys"]
 +++
 
+> **Attention: The maintenance guideline that this introduction is describing has been deprecated from October 25, 2020.** We've switched to a newly-proposed [Topic-Based Maintenance Guidelines](@/developer/packaging/topic-based-maintenance-guideline.md). Before we update this document, you could refer to that document instead, or stay tuned.
+
 This policy covers .NET packages in AOSC OS, like `dotnet-*` and `mono`, which are maintained by Microsoft and the .NET community<sup>[1][1],[2][2]</sup>.
 
 # .NET Core `dotnet-*`

--- a/content/developer/packaging/dotnet.zh.md
+++ b/content/developer/packaging/dotnet.zh.md
@@ -6,6 +6,8 @@ date = 2020-05-04T03:35:48.616Z
 tags = ["dev-sys"]
 +++
 
+> **注意：本入门所描述的维护指南自 2020 年 10 月 25 日起已被弃用。**我们已经开始实践新提出的[话题制维护指南 (English)](@/developer/packaging/topic-based-maintenance-guideline.md)。在我们更新这篇文档之前，您可以左转阅读那份指南，或者坐等更新。
+
 以下的生命周期策略适用于 AOSC OS 中所有的 .NET 软件包，包括微软和 .NET 社区维护的 `dotnet-*` 和 `mono`<sup>[\[1\]][1][\[2\]][2]</sup>。
 
 # .NET Core `dotnet-*`

--- a/content/developer/packaging/known-patch-release-rules.md
+++ b/content/developer/packaging/known-patch-release-rules.md
@@ -6,6 +6,8 @@ date = 2020-05-04T03:35:51.153Z
 tags = ["dev-sys"]
 +++
 
+> **Attention: This guideline has been deprecated from October 25, 2020.** We've switched to a newly-proposed [Topic-Based Maintenance Guidelines](@/developer/packaging/topic-based-maintenance-guideline.md); please refer to that document instead.
+
 # Description
 
 The AOSC OS "Stable" channel under the new *TODO: SEASONAL UPDATE MODEL* requires that only packages with *known* patch-level release rules could be updated in this channel, for example, when GNOME Terminal (`gnome-terminal`) is to be update from `3.30.0` to `3.30.1`, this is permitted, as we know that this is a patch release as [dictated](https://developer.gnome.org/programming-guidelines/stable/versioning.html.en#stable-unstable-versions) by GNOME - on the contrary, an update from `3.30.0` to `3.31.0` (stable to unstable) or even from `3.30.0` to `3.32.0` (stable to next-stable) are not acceptable.
@@ -45,4 +47,4 @@ The packages and projects found below should never be updated via the Stable cha
 | Deepin Desktop Environment and Applications | No predictable release and versioning model - as suggested one Deepin developer. |
 | LibQalculate | From `2.6.1` to `2.6.2`, for instance, .so version changed from 18 to 19, breaking ABI compatibility. This does not comply with [Semantic Versioning](https://semver.org/). |
 | Trinity Desktop Environment and Applications | An apparently patch-level release, say, from `R14.0.4` to `R14.0.5` may introduce changes to build system and mix in a large amount of feature updates. |
-| HDF5 (Hierarchical Data Format) | Patch release update changes `sover`, for example, `1.10.1` contains `libhdf5.so.101`, and `1.10.3`, which should have been a patch release update, contains `libhdf5.so.103`, breaking binary compatibility. | 
+| HDF5 (Hierarchical Data Format) | Patch release update changes `sover`, for example, `1.10.1` contains `libhdf5.so.101`, and `1.10.3`, which should have been a patch release update, contains `libhdf5.so.103`, breaking binary compatibility. |

--- a/content/developer/packaging/maintenance-guidelines.md
+++ b/content/developer/packaging/maintenance-guidelines.md
@@ -1,10 +1,12 @@
 +++
-title = "AOSC OS Maintenance Guidelines"
+title = "AOSC OS Maintenance Guidelines (Deprecated)"
 description = "General Procedural Guidlelines for AOSC OS Package Maintenance"
 date = 2020-05-04T03:35:53.850Z
 [taxonomies]
 tags = ["dev-sys"]
 +++
+
+> **Attention: This guideline has been deprecated from October 25, 2020.** We've switched to a newly-proposed [Topic-Based Maintenance Guidelines](@/developer/packaging/topic-based-maintenance-guideline.md); please refer to that document instead.
 
 # Introduction
 
@@ -19,7 +21,7 @@ The concepts of branches, cycles, and ports are three main aspects that maintena
 AOSC OS is maintained *concurrently* across four branches:
 
 - Stable (`stable`): Main maintenance branch which most users should be using, updates include security updates, bug fixes, [exceptional updates](@/developer/packaging/cycle-exceptions.md) and [patch-level updates](@/developer/packaging/known-patch-release-rules.md).
-	- Stable, Proposed Updates (`stable-proposed`): Feeds said updates into `stable`, unless the current `stable` already requires bug fixes (for instance, a currently available `stable` package has broken dependency). 
+	- Stable, Proposed Updates (`stable-proposed`): Feeds said updates into `stable`, unless the current `stable` already requires bug fixes (for instance, a currently available `stable` package has broken dependency).
 - Testing (`testing`): Main feature branch which users with particular interest in following the latest development and changes should be using, security updates, feature/major updates, and new packages are introduced from the `explosive` branch and tested *minimally* before shipping. Updates made available through this branch will be available for `stable` by the end of each update cycle.
 	- Testing, Proposed Updates (`testing-proposed`): Feeds said updates into `testing`, packages are introduced and *build-time tested*.
 - Explosive (`explosive`): Accepts *any* new packages and updates *outside of the release cycles*. No one should be using this branch, no matter what.

--- a/content/developer/packaging/maintenance-guidelines.zh.md
+++ b/content/developer/packaging/maintenance-guidelines.zh.md
@@ -1,10 +1,12 @@
 +++
-title = "AOSC OS 维护指南（征求意见稿）"
-description = "过好生活，打好包包"
+title = "AOSC OS 维护指南（已弃用）"
+description = "AOSC OS 软件包维护过程一般指南"
 date = 2020-08-06T12:50:03.911Z
 [taxonomies]
 tags = ["dev-sys"]
 +++
+
+> **注意：本维护指南自 2020 年 10 月 25 日起已被弃用。**我们已经开始实践新提出的[话题制维护指南 (English)](@/developer/packaging/topic-based-maintenance-guideline.md)；请左转阅读那份指南。
 
 # 概述
 

--- a/content/developer/packaging/topic-based-maintenance-guideline.md
+++ b/content/developer/packaging/topic-based-maintenance-guideline.md
@@ -1,5 +1,5 @@
 +++
-title = "AOSC OS Topic-Based Maintenance Guidelines (RFC)"
+title = "AOSC OS Topic-Based Maintenance Guidelines"
 description = "General Procedural Guidlelines for AOSC OS Package Maintenance"
 date = 2020-05-04T03:35:53.850Z
 [taxonomies]
@@ -232,7 +232,7 @@ After each synchronisation (or merge) from the `stable` branch, a Pull
 Request is created against the `stable` branch as a `retro-tracking-$YEAR`
 topic. Follow all procedures and rules above.
 
-# Documentation 
+# Documentation
 
 ## Changes Required Following This Change
 


### PR DESCRIPTION
Many of the wiki articles referring to the just-deprecated [maintenance guideline](https://github.com/AOSC-Dev/wiki/blob/topic-based-updates/content/developer/packaging/maintenance-guidelines.md) should be updated to reflect the [topic-based maintenance guideline](https://github.com/AOSC-Dev/wiki/blob/topic-based-updates/content/developer/packaging/topic-based-maintenance-guideline.md).