### PR TITLE
macros: hide also_available_in on one translation

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -12,7 +12,7 @@
 
 {% macro language_select(source) %}
   <div class="right">
-    {% if source.translations | length > 0 %}
+    {% if source.translations | length > 1 %}
       {{ trans(key="also_available_in", lang=lang) }}
       {% for t in source.translations %}
         {% if t.lang != lang %}


### PR DESCRIPTION
This PR expects to hide the "Also available:" area when no other language variants are present.

![image](https://user-images.githubusercontent.com/19144373/122631702-00e2c980-d100-11eb-89e7-956b6f19e78b.png)
