### PR TITLE
installation/wsl*: rewrite the guide

### DIFF
--- a/content/aosc-os/installation/wsl.md
+++ b/content/aosc-os/installation/wsl.md
@@ -1,79 +1,23 @@
 +++
 title = "Installation/WSL"
-description = "Installing AOSC OS on Windows Subsystems for Linux"
-date = 2020-09-01T01:28:00.00Z
+description = "Install AOSC OS on WSL"
+date = 2021-07-23T22:50:00.00Z
 [taxonomies]
 tags = ["sys-installation"]
 +++
 
-It is surprisingly easy to run AOSC OS on Windows Subsystems on Linux.
+# Install WSL
 
-# Forenotes
+Please see [Windows Subsystem for Linux Installation Guide for Windows 10](https://docs.microsoft.com/en-us/windows/wsl/install-win10). If you want to run Linux GUI apps, also see [Run Linux GUI apps on the Windows Subsystem for Linux (preview)](https://docs.microsoft.com/en-us/windows/wsl/tutorials/gui-apps).
 
-WSL comes in two flavors:
+# Get AOSC OS on WSL
 
-* WSL1, which has the NT kernel mimic a Linux kernel with no graphics and no 32-bit support;
-* WSL2, which uses the Windows Hypervisor Platform to run the distribution's own kernel.
+It's the easiest way to get AOSC OS on WSL from Microsoft Store.
 
-You naturally need to first enable WSL to proceed. Read [Microsoft's guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10) on how.
+<a href='//www.microsoft.com/store/apps/9NMDF21NV65Z?cid=storebadge&ocid=badge'><img src='https://developer.microsoft.com/store/badges/images/English_get_L.png' alt='English badge' style='width: 127px; height: 52px;'/></a>
 
-# Choosing a tarball
+If you're running a Windows Server or Long-Term Servicing (LTSC) desktop OS SKU that doesn't support Microsoft Store, or your corporate network policies and/or admins to not permit Microsoft Store usage in your environment, you can get AOSC OS on WSL for your architecture from [GitHub Releases](https://github.com/AOSC-Dev/AOSCOSLauncher/releases/latest). Extract all files from the compressed folder, then run Install.ps1 in it.
 
-As of the time of writing, WSL is only supported on AMD64 devices. Please check the section in the [AMD64 Guide](@/aosc-os/installation/amd64.md#choosing-a-tarball).
+# Configure AOSC OS
 
-# Unpacking the tarball
-
-[LxRunOffline](https://github.com/DDoSolitary/LxRunOffline) is a great tool for managing WSL installs. Among other things that Microsoft does not yet provide, it:
-
-* Allows us to use `xz`-compressed tarballs
-* Allows users to place distributions wherever they want
-* Allows tweaking all configurations in the WSL distro registry
-
-After you have download the tarball and the tool, run the following in PowerShell:
-
-```powershell
-# Unpack the distro (avoid using a name with spaces!)
-& ".\LxRunOffline.exe" install `
-  -n AOSC-Whatever `
-  -d C:\path\to\the\target `
-  -f C:\path\to\the\tarball `
-  -s
-```
-
-**Note**: as is the case for any type of installation, you can greatly speed up the process by temporarily disabling your antivirus or by adding the target directory to an exclusion list.
-
-Now that the OS is known to WSL, you can start it using any of the usual ways: with `LxRunOffline`, in a new tab in Windows Terminal, or using the desktop shortcut that has just been created.
-
-# Setting up your system
-
-Some more configuration is needed for the WSL system to interoperate with Windows properly. Enter a root shell in the new WSL instance of AOSC OS and run:
-
-```bash
-# Remove /etc/resolv.conf so WSL can generate it for us
-rm /etc/resolv.conf
-# Put sane defaults in /etc/wsl.conf
-cat > /etc/wsl.conf << 'EOF'
-[automount]
-options = "metadata,umask=22,fmask=11"
-EOF
-# Leave setting PATH to WSL so appends will work
-sed -e '/^unset PATH MANPATH/d' \
-    -i /etc/profile
-```
-
-Now exit the shell and re-open it. You should have a functional, if a bit unorthodox, system available. Continue to the [User, and Post-installation Configuration](@/aosc-os/installation/amd64.md#user-and-post-installation-configuration) section of the AMD64 guide.
-
-LxRunOffline cannot create WSL2 instances. You may convert the WSL1 instance to WSL2 using `wsl  --set-version AOSC-Whatever 2` ([MS documentation](https://docs.microsoft.com/en-us/windows/wsl/install-win10)). Note that you need to keep the installation path [uncompressed and unencrypted](https://github.com/microsoft/WSL/issues/4103), or you may get an error while creating the VHDX file.
-
-# Any more plumbing needed?
-
-Sadly, yes.
-
-<!-- can we use https://www.markdownguide.org/extended-syntax#definition-lists ? -->
-<dl>
-  <dt>Graphics</dt>
-  <dd>Apparently we need [Xvnc and a heavily modified version of systemd](https://most-useful.com/ubuntu-20-04-desktop-gui-on-wsl-2-on-surface-pro-4/) for a graphical login screen. Add that to the packaging list.</dd>
-  <dt>Windows Store</dt>
-  <dd>We will eventually need to provide gzipped tarballs when we want to submit AOSC OS to Windows Store. Unless Microsoft [gets its act together](https://github.com/microsoft/WSL/issues/4736), that is.</dd>
-  <dd>And we better fix the ugly `/etc/profile` hack before we submit. Not that Microsoft cares.</dd>
-</dl>
+Please see [Create a user account and password for your new Linux distribution](https://docs.microsoft.com/en-us/windows/wsl/user-support), AOSC OS also uses apt to manage packages.

--- a/content/aosc-os/installation/wsl.zh.md
+++ b/content/aosc-os/installation/wsl.zh.md
@@ -1,74 +1,23 @@
 +++
-title = "Installation/WSL (简体中文)"
-description = "在 WSL 安装 AOSC OS"
-date = 2020-09-01T01:28:00.00Z
+title = "Installation/WSL（简体中文）"
+description = "在适用于 Linux 的 Windows 子系统上安装 AOSC OS"
+date = 2021-07-23T22:50:00.00Z
 [taxonomies]
 tags = ["sys-installation"]
 +++
 
-事实上，在 WSL（适用于 Linux 的 Windows 子系统）上安装 AOSC OS 比您想的要简单很多。
+# 安装 WSL
 
-# 写在前面
+请参阅[适用于 Linux 的 Windows 子系统安装指南 (Windows 10)](https://docs.microsoft.com/zh-cn/windows/wsl/install-win10)。如果想要运行 Linux GUI 应用程序，也请参阅[在预览版适用于 Linux 的 Windows 子系统 (运行 Linux GUI)](https://docs.microsoft.com/zh-cn/windows/wsl/tutorials/gui-apps)。
 
-WSL 又分为 WSL 1 和 WSL 2 两个版本：
+# 获取 AOSC OS on WSL
 
-* WSL 1 创建了一个转换层，对系统调用进行翻译，以允许它们在 Windows NT 内核上工作。
-* WSL 2 包含自己的 Linux 内核，它具有完整的系统调用兼容性。
+从 Microsoft Store 获取 AOSC OS on WSL 是最简单的方法。
 
-在开始下一步之前，请先阅读 [微软官方文档](https://docs.microsoft.com/en-us/windows/wsl/install-win10) 了解如何在您的 Windows 系统上启用 WSL。
+<a href='//www.microsoft.com/store/apps/9NMDF21NV65Z?cid=storebadge&ocid=badge'><img src='https://developer.microsoft.com/store/badges/images/Chinese_Simplified_Get_L.png' alt='Chinese badge' style='width: 127px; height: 52px;'/></a>
 
-# 选择一个 Tarball
+如果你正在运行不支持 Microsoft Store 的 Windows Server 或长期服务 (LTSC) 桌面操作系统 SKU，或者你的公司网络策略和/或管理员不允许在你的环境中使用 Microsoft Store，你可以从 [GitHub Releases](https://github.com/AOSC-Dev/AOSCOSLauncher/releases/latest) 获取适用于你的体系结构的 AOSC OS on WSL。从压缩的文件夹提取全部文件，然后运行其中的 Install.ps1。
 
-截止 2020 年 9 月，WSL 只支持 AMD64 设备，请阅读 [AMD64 安装指南](@/aosc-os/installation/amd64.zh.md#xuan-ze-yi-ge-tarball) 了解可用的 Tarball。
+# 配置 AOSC OS
 
-# 解压 Tarball
-
-[LxRunOffline](https://github.com/DDoSolitary/LxRunOffline) 可以很好地管理 WSL 实例，它还提供一些微软尚未提供的功能，例如：
-
-- 使用基于 `xz` 压缩方案的 Tarball。
-- 支持自定义发行版安装路径。
-- 对 WSL 发行版注册表进行修改。
-
-在下载好 Tarball 和上面提到的工具之后，在 PowerShell 中运行：
-
-```powershell
-# Unpack the distro (avoid using a name with spaces!)
-& ".\LxRunOffline.exe" install `
-  -n AOSC-Whatever `
-  -d C:\path\to\the\target `
-  -f C:\path\to\the\tarball `
-  -s
-```
-
-接下来您就可以使用常规的方式启动装好的 AOSC OS 了：可以使用 `LxRunOffline`，可以在 Windows Terminal 新建选项卡，也可以直接使用刚刚创建好的快捷方式。
-
-# 安装后配置
-
-为了实现 WSL 系统和 Windows 系统的交互，您需要在 WSL 中新创建的 AOSC OS 实例内使用管理员身份执行：
-
-```bash
-# Remove /etc/resolv.conf so WSL can generate it for us
-rm /etc/resolv.conf
-# Put sane defaults in /etc/wsl.conf
-cat > /etc/wsl.conf << 'EOF'
-[automount]
-options = "metadata,umask=22,fmask=11"
-EOF
-# Leave setting PATH to WSL so appends will work
-sed -e '/^unset PATH MANPATH/d' \
-    -i /etc/profile
-```
-
-重启 WSL 系统，接下来请参照 [这篇指南](@/aosc-os/installation/amd64.zh.md#yong-hu-zi-ding-yi-she-zhi) 完成用户创建等剩余的设定。
-
-LxRunOffline 不支持创建 WSL2 实例。如果需要 WSL2 实例，只能在安装后手动转换为 WSL，具体参考[微软网站上的文档](https://docs.microsoft.com/en-us/windows/wsl/install-win10)。另外注意，硬盘[不能开启加密或压缩](https://github.com/microsoft/WSL/issues/4103)，否则可能会转换失败。
-
-# 下一步...
-
-## 图形界面
-
-为了让图形化登录登录管理器工作，我们需要 [魔改版 systemd 以及 Xvnc](https://most-useful.com/ubuntu-20-04-desktop-gui-on-wsl-2-on-surface-pro-4/)。我们正在将它们添加到我们的打包列表中。
-
-## 微软应用商店
-
-要想将 AOSC OS 提交到微软应用商店，[除非微软采纳我们的建议](https://github.com/microsoft/WSL/issues/4736)，不然我们就要制作基于 Gzip 压缩算法的 Tarball。此外在提交前我们也需要将 `/etc/profile` 问题修复好。
+请参阅[为新的 Linux 分发版创建用户帐户和密码](https://docs.microsoft.com/zh-cn/windows/wsl/user-support)，AOSC OS 也使用 apt 管理软件包。


### PR DESCRIPTION
- Refer to Microsoft Docs as long as it suits the need
- Launcher is now the preferred way to install AOSC OS on WSL.

Closes #25.