### PR TITLE
add workflow to make PDF artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 public/
+.dist/

--- a/.pentex/std.H.tex
+++ b/.pentex/std.H.tex
@@ -1,0 +1,112 @@
+\usepackage{xeCJK,xeCJKfntef}
+\usepackage{calc,fontspec,listings,tcolorbox,paralist,enumitem,makecmds}
+\usepackage{graphicx,eso-pic,datetime2}
+
+% ============================================
+% Adjust fonts here...
+% ============================================
+\setmainfont{Noto Serif}
+\setromanfont{Noto Serif}
+\setsansfont{Inter}
+\setmonofont{JetBrains Mono NL}
+
+\setCJKmainfont{Noto Serif CJK SC}
+\setCJKromanfont{Noto Serif CJK SC}
+\setCJKsansfont{Noto Sans CJK SC}
+\setCJKmonofont{Noto Sans CJK SC}
+
+
+% ============================================
+% Style settings
+% ============================================
+\frenchspacing
+\linespread{1.21}
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{6pt}
+
+\usepackage{hyperref}
+\hypersetup{
+    colorlinks=true,
+    linkcolor=blue,
+    urlcolor=cyan,
+    citecolor=magenta,
+}
+
+
+
+
+% ============================================
+% Fix the "too deeply nested" error
+% ============================================
+\setlistdepth{9}
+\setlist[itemize,1]{label=$\bullet$}
+\setlist[itemize,2]{label=$\bullet$}
+\setlist[itemize,3]{label=$\bullet$}
+\setlist[itemize,4]{label=$\bullet$}
+\setlist[itemize,5]{label=$\bullet$}
+\setlist[itemize,6]{label=$\bullet$}
+\setlist[itemize,7]{label=$\bullet$}
+\setlist[itemize,8]{label=$\bullet$}
+\setlist[itemize,9]{label=$\bullet$}
+\renewlist{itemize}{itemize}{9}
+
+\setlist[enumerate,1]{label=$\arabic*.$}
+\setlist[enumerate,2]{label=$\alph*.$}
+\setlist[enumerate,3]{label=$\roman*.$}
+\setlist[enumerate,4]{label=$\arabic*.$}
+\setlist[enumerate,5]{label=$\alpha*$}
+\setlist[enumerate,6]{label=$\roman*.$}
+\setlist[enumerate,7]{label=$\arabic*.$}
+\setlist[enumerate,8]{label=$\alph*.$}
+\setlist[enumerate,9]{label=$\roman*.$}
+\renewlist{enumerate}{enumerate}{9}
+
+
+% ============================================
+% Overwrite some default commands
+% ============================================
+\makeatletter
+\renewcommand{\maketitle}[0]{
+    \parbox{\linewidth}{
+        \sffamily\raggedright
+        \includegraphics[width=18mm]{./static/img/aosc.png}\par\vskip 15pt
+        \large
+        \bfseries AOSC Wiki\par\vskip 8pt
+        \bfseries
+        \LARGE\@title\par\vskip 15pt
+        \small\mdseries\copyright~AOSC Contributors (License: CC BY 4.0) \hfill Last build: \today
+    }\par
+    \vskip 18pt
+    \hrule
+    \vskip 36pt
+}
+\makeatother
+
+\let\oldstdhref\href
+\renewcommand{\href}[2]{\oldstdhref{#1}{\textcolor{blue!80!green!90!black}{\CJKunderline{#2}}}}
+
+\let\oldstdtableofcontents\tableofcontents
+\renewcommand{\tableofcontents}[0]{\oldstdtableofcontents\vfill\clearpage}
+
+
+
+
+
+
+
+
+
+
+
+
+
+% ============================================
+% <pre> and <code>
+% ============================================
+\makeatletter
+\renewcommand{\texttt}[1]{%
+    \mbox{\textcolor{black!18!red}{\ttfamily#1}}%
+}
+\provideenvironment{Shaded}{}{}
+\renewenvironment{Shaded}{\begingroup\footnotesize\begin{tcolorbox}[colback=white!96!black,colframe=black!40!white,boxrule=0.6pt,arc=2.5pt,top=4pt,bottom=4pt,left=4pt,right=4pt]}{\end{tcolorbox}\endgroup}
+\makeatother

--- a/pentex.sh
+++ b/pentex.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+##############################################################################
+# Get the `pentex` script from https://github.com/neruthes/pentex
+##############################################################################
+
+##############################################################################
+#   ./pentex.sh all
+#           Build PDF artifacts for all Markdown files.
+#   ./pentex.sh content/1.md content/2.md
+#           Build multiple artifacts at once.
+##############################################################################
+
+
+EXTRA_ARGS=(
+    -V "fontsize:10pt"
+    -V "geometry:textwidth=43em,vmargin=25mm"
+    --pdf-engine-opt="--shell-escape"
+)
+
+mkdir -p .dist/pdf
+
+function remove_header() {
+    fn="$1"
+    line_num=$(grep -n -m 2 '+++' "$fn" | tail -n 1 | cut -d ':' -f 1)
+    # Remove all lines up to and including the second occurrence of "+++"
+    sed "1,${line_num}d" "$fn"
+}
+
+function makepdf() {
+    mdpath="$1"
+    pdfpath="$(sed 's|^content|.dist/pdf|' <<< "$mdpath.pdf")"
+    url_base="https://wiki.aosc.io/$(cut -d/ -f2- <<< "$mdpath" | sed 's|.md$|/|')"
+    mkdir -p "$(dirname "$pdfpath")"
+    md_title="$(grep -m1 'title = ' "$mdpath" | sed 's|^title = ||' | tr -d '"')"
+    H=.pentex/std.H.tex pentex <(
+        remove_header "$mdpath"
+    ) --shift-heading-level-by=0 -o "$pdfpath" \
+        -V title:"$md_title" \
+        -V url-base:"$url_base" \
+        "${EXTRA_ARGS[@]}"
+}
+
+
+
+case $1 in
+    all)
+        find content -name '*.md' -type f | while read -r fn; do
+            makepdf "$fn"
+        done
+        exit 0
+        ;;
+esac
+
+
+
+if [[ -e "$2" ]]; then
+    for fn in "$@"; do
+        makepdf "$fn"
+    done
+else
+    makepdf "$1"
+fi
+
+


### PR DESCRIPTION
Run `./pentex.sh all` to build PDF artifacts for all Markdown files.

Or run `./pentex.sh content/*.md` to build PDF for certain Markdown files.

Preview some artifacts:

- [Full list of cached artifacts](https://nas-public.neruthes.xyz/wiki-bb36e17a9e8d4e889bda8248/.dist/pdf/)
- [livekit.md.pdf](https://minio.neruthes.xyz/oss/keep/wiki/livekit.md.pdf--b7d122b38bd89438e337bb42c93002d1.pdf)
- [livekit.zh.md.pdf](https://minio.neruthes.xyz/oss/keep/wiki/livekit.zh.md.pdf--5f74daf6aa67ce30b002e6dbb2a5bbf2.pdf)
- [rawimgs.md.pdf](https://minio.neruthes.xyz/oss/keep/wiki/rawimgs.md.pdf--0ba2c3757d7aad33c32fe852d1461c35.pdf)
- [rawimgs.zh.md.pdf](https://minio.neruthes.xyz/oss/keep/wiki/rawimgs.zh.md.pdf--efed353cad287d9a73d9b91196de83e8.pdf)
- [wsl.md.pdf](https://minio.neruthes.xyz/oss/keep/wiki/wsl.md.pdf--d2fde89fb819ee1a14bbdb9dabf81fe2.pdf)
- [wsl.zh.md.pdf](https://minio.neruthes.xyz/oss/keep/wiki/wsl.zh.md.pdf--6ae6d20ac9610a33523ffabbc45a1053.pdf)


And should we add artifact building into CI config in another PR...?