### PR TITLE
packaging/styling-manual: specify a more accurate version scheme for VCS sources

### DIFF
--- a/content/developer/packaging/package-styling-manual.md
+++ b/content/developer/packaging/package-styling-manual.md
@@ -73,7 +73,9 @@ The `VER=`, or `$VER` variable defines the main version of the resulting package
 | Versions with underscore(s) ("\_") | Replace the underscore(s) with dot(s) ("."). |  Icarus Verilog 10_2 -> `VER=10.2` |
 | Versions with release stage notation(s) ("alpha", "beta", "rc", etc.) | Lower-case all notations, "Beta" to "beta", etc. Prepend a tilde ("~"). | Golden Dict 1.5.0-RC2 -> `VER=1.5.0~rc2` |
 | Versions with formatted date(s) | Replace dash(es) ("-") with dots ("."). | QuickJS 2020-09-06 -> `VER=2020.09.06` |
-| Git or other VCS snapshots | Write last tagged version (e.g. "3.2.1") or "0" if never tagged, then append "+", VCS name (e.g. "git") and date of commit. | Shadowsocks 5ff694b2c2978b432918dea6ac104706b25cbf48 -> `VER=0+git20181219` |
+| Git or other VCS snapshots | Write last tagged version (e.g. "3.2.1") or "0" if never tagged, then append "+", VCS name (e.g. "git"), date of commit, and revision number (and optionally, where available, a short reference hash). Schema: `${VER}+${VCS_NAME}.r${REV_COUNT}[.${SHORT_HASH}]` [^1] | Nano 7f4c2c6a2556ecab6a8c2018a5f44b7fbdfc092d -> `VER=7.2+git20230602.r10185.7f4c2c6a` |
+
+[^1] For Git, you may append the information after `+` automatically by running this command from within a local source repository (please take note to replace the `[commit_hash]` with your specified commit): `echo git$(git show -s --format=%ci [commit_hash] | cut -f1 -d' ' | sed -e 's|-||g').r$(git rev-list --count [commit_hash]).$(git rev-parse --short [commit_hash])`.
 
 ### REL=
 

--- a/content/developer/packaging/package-styling-manual.zh.md
+++ b/content/developer/packaging/package-styling-manual.zh.md
@@ -77,6 +77,9 @@ Executed Packager <suffering@pakreq.work>
 | 版本号带有发布阶段标记（`alpha`、`beta`、`rc`） | 将字母转为小写，并在字母前加波浪号（`~`） | Golden Dict 1.5.0-RC2 -> `VER=1.5.0~rc2` |
 | 版本号为格式化后的日期 | 将短横线替换为小数点 (`.`) | QuickJS 2020-09-06 -> `VER=2020.09.06` |
 | 版本号基于版本控制系统的提交哈希值 | 由最后 tag 版本开头（如“3.2.1”），如从未 tag 则写“0”；而后接上“+”、版本控制器名称（如“git”）及提交日期 | Shadowsocks 5ff694b2c2978b432918dea6ac104706b25cbf48 -> `VER=0+git20181219` |
+| 版本号基于版本控制系统的提交哈希值 | 由最后 tag 版本开头（如“3.2.1”），如从未 tag 则写“0”；而后接上“+”、版本控制器名称（如“git”）、提交日期及修订编号（如版本控制系统允许，还需附加短提交哈希值）；基本格式：`${VER}+${VCS_NAME}.r${REV_COUNT}[.${SHORT_HASH}]` [^1] | Nano 7f4c2c6a2556ecab6a8c2018a5f44b7fbdfc092d -> `VER=7.2+git20230602.r10185.7f4c2c6a` |
+
+[^1] 对于 Git 仓库，您可以通过在本地仓库中运行如下命令自动补全 `+` 后的版本信息（请注意将 `[commit_hash]` 更改为对应的提交哈希值）：`echo git$(git show -s --format=%ci [commit_hash] | cut -f1 -d' ' | sed -e 's|-||g').r$(git rev-list --count [commit_hash]).$(git rev-parse --short [commit_hash])`.
 
 ### REL
 


### PR DESCRIPTION
This pull request proposes a more accurate version scheme for VCS/snapshot sources. Whereas previously, a package built from a Git snapshot would carry a version number like:

```
7.2+git20230602
```

The new scheme proposes adding:

- Revision count for the specific snapshot/commit.
- A short hash (where applicable) for the specific snapshot/commit.

Resulting in the following:

```
7.2+git20230602.r10185.7f4c2c6a
```