### PR TITLE
'开发者/打包/.'进阶教程的链接修改到中文篇

### DIFF
--- a/content/developer/packaging/basics.zh.md
+++ b/content/developer/packaging/basics.zh.md
@@ -238,4 +238,4 @@ ciel build -i main light
 
 恭喜，您已掌握为 AOSC OS 引入、更新、构建和上传软件包的基础技能！
 
-但如您所见，本文只概述了软件包维护的基础知识点。在需要构建更复杂的软件包和批量更新软件包之前，您还需要学习一些进阶知识。请参阅[软件包维护入门：进阶教程](@/developer/packaging/advanced-techniques.md)。
+但如您所见，本文只概述了软件包维护的基础知识点。在需要构建更复杂的软件包和批量更新软件包之前，您还需要学习一些进阶知识。请参阅[软件包维护入门：进阶教程](@/developer/packaging/advanced-techniques.zh.md)。


### PR DESCRIPTION
指向 "advanced-techniques.md" 的链接被修改为指向 "advanced-techniques.zh.md"