### PR TITLE
Fix compatibility with Zola >= 0.22

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,8 +14,11 @@ taxonomies = [
     {name = "tags", lang = "zh"},
 ]
 
-[markdown]
-highlight_code = true
+[markdown.highlighting]
+error_on_missing_language = false
+style = "inline"
+light_theme = "min-light"
+dark_theme = "material-theme-darker"
 
 [extra]
 logo = "/img/aosc.png"

--- a/content/aosc-os/aosa/_index.md
+++ b/content/aosc-os/aosa/_index.md
@@ -1,10 +1,7 @@
 +++
 title = "AOSC OS Security Advisories (AOSA)"
 description = "Tracking of security vulnerabilities found in AOSC OS"
-date = 2020-05-04T03:35:01.002Z
 insert_anchor_links = "right"
-[taxonomies]
-tags = ["aosa"]
 +++
 
 # AOSA?

--- a/content/aosc-os/aosa/_index.zh.md
+++ b/content/aosc-os/aosa/_index.zh.md
@@ -1,10 +1,7 @@
 +++
 title = "AOSC OS 安全公告系统 (AOSA)"
 description = "跟踪 AOSC OS 中发现的安全漏洞 "
-date = 2020-08-02T14:17:30.417Z
 insert_anchor_links = "right"
-[taxonomies]
-tags = ["aosa"]
 +++
 
 # AOSA？

--- a/content/aosc-os/devices/apple/macmini9-1/_index.zh.md
+++ b/content/aosc-os/devices/apple/macmini9-1/_index.zh.md
@@ -1,9 +1,6 @@
 +++
 title = "Mac Mini（2020 年末）"
 description = "用于 Mac Mini Late 2020 的支持文档"
-date = 2021-06-02
-[taxonomies]
-tags = ["sys-installation"]
 +++
 
 

--- a/content/developer/packaging/autobuild4/_index.md
+++ b/content/developer/packaging/autobuild4/_index.md
@@ -1,7 +1,5 @@
 +++
 title = "Autobuild4"
-[taxonomies]
-tags = ["dev-sys"]
 +++
 
 Autobuild4 is a successor to the [previous generation of Autobuild](https://github.com/AOSC-Dev/autobuild).


### PR DESCRIPTION
* Remove dropped fields in section index pages like `date` and `taxonimies`.
* Adjust `config.toml` accordingly, as they have switched to a new syntax highlighting engine.